### PR TITLE
Fix #1: Adding an option to print the level in String instead of Integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ log.error('OOOOHHH it burns!', new Error('temperature: 200'));
 log.fatal('I died! Do you know what that means???');
 ```
 
+* Printing the level in String representation for Json objects
+
+```js
+var bunyan = require('bunyan')
+  , bformat = require('../')
+  , formatOut = bformat({ outputMode: 'bunyan', levelInString: true })
+  ;
+```
+
+The output would use the string levels:
+
+```
+$ node example/json-string-level.js 
+{"name":"app","hostname":"ubuntu","pid":28081,"level":"INFO","msg":"starting up","time":"2014-12-01T19:41:29.136Z","v":0}
+{"name":"app","hostname":"ubuntu","pid":28081,"level":"DEBUG","msg":"things are heating up { temperature: 80,\n  status: { started: 'yes', overheated: 'no' } }","time":"2014-12-01T19:41:29.142Z","v":0}
+{"name":"app","hostname":"ubuntu","pid":28081,"level":"WARN","msg":"getting a bit hot { temperature: 120 }","time":"2014-12-01T19:41:29.143Z","v":0}
+{"name":"app","hostname":"ubuntu","pid":28081,"level":"ERROR","msg":"OOOOHHH it burns! [Error: temperature: 200]","time":"2014-12-01T19:41:29.144Z","v":0}
+{"name":"app","hostname":"ubuntu","pid":28081,"level":"FATAL","msg":"I died! Do you know what that means???","time":"2014-12-01T19:41:29.144Z","v":0}
+```
+
 ![demo](https://github.com/thlorenz/bunyan-format/raw/master/assets/bunyan-format-demo.gif)
 
 ## Installation

--- a/example/bunyan-string-level.js
+++ b/example/bunyan-string-level.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var bunyan = require('bunyan')
+  , bformat = require('../')  
+  , formatOut = bformat({ outputMode: 'bunyan', levelInString: true })
+  ;
+
+var log = bunyan.createLogger({ name: 'app', stream: formatOut, level: 'debug' } );
+
+log.info('starting up');
+log.debug('things are heating up', { temperature: 80, status: { started: 'yes', overheated: 'no' } });
+log.warn('getting a bit hot', { temperature: 120 });
+log.error('OOOOHHH it burns!', new Error('temperature: 200'));
+log.fatal('I died! Do you know what that means???');

--- a/lib/format-record.js
+++ b/lib/format-record.js
@@ -86,6 +86,29 @@ function stylizeWithoutColor(str, color) {
 }
 
 /**
+ * @param {int} level is the level of the record.
+ * @return The level value to its String representation.
+ * This is only used on json-related formats output and first suggested at 
+ * https://github.com/trentm/node-bunyan/issues/194#issuecomment-64858117
+ */
+function mapLevelToName(level) {
+  switch (level) {
+    case TRACE:
+      return 'TRACE';
+    case DEBUG:
+      return 'DEBUG';
+    case INFO:
+      return 'INFO';
+    case WARN:
+      return 'WARN';
+    case ERROR:
+      return 'ERROR';
+    case FATAL:
+      return 'FATAL';
+  }
+}
+
+/**
  * Print out a single result, considering input options.
  */
 module.exports = function formatRecord(rec, opts) {
@@ -368,9 +391,15 @@ module.exports = function formatRecord(rec, opts) {
     return util.inspect(rec, false, Infinity, true) + '\n';
 
   case OM_BUNYAN:
+    if (opts.levelInString) {
+      rec.level = mapLevelToName(rec.level);
+    }
     return JSON.stringify(rec, null, 0) + '\n';
 
   case OM_JSON:
+    if (opts.levelInString) {
+      rec.level = mapLevelToName(rec.level);
+    }
     return JSON.stringify(rec, null, opts.jsonIndent) + '\n';
 
   case OM_SIMPLE:
@@ -386,3 +415,4 @@ module.exports = function formatRecord(rec, opts) {
     throw new Error('unknown output mode: '+opts.outputMode);
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-format",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Writable stream that formats bunyan records that are piped into it.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This commit fixes Issue #1 by adding an option to display the level
using its String representation. Suggesting it to be the 0.2.0 version. This was first discussed at https://github.com/trentm/node-bunyan/issues/194, but since I use this module, I decided to start here... So contributing back!
-   modified:   lib/format-record.js
- Adding a method to map the level suggested by @olsonpm at
  https://github.com/trentm/node-bunyan/issues/194#issuecomment-64858117
- If the option is used, just change the level.
-   modified:   README.md
- Updating the documentation by adding the examples of outputing the
  reports using the levels in String.
-   new file:   example/bunyan-string-level.js
- Adding the new example that logs the level using the string
  representation.
-   modified:   package.json
- Bumping the version to 0.2.0
