### PR TITLE
Added rec.err.cause support.

### DIFF
--- a/lib/format-record.js
+++ b/lib/format-record.js
@@ -108,6 +108,18 @@ function mapLevelToName(level) {
   }
 }
 
+function getFullErrorStack(ex) {
+    var ret = ex.stack || ex.toString();
+    var cex = ex.cause;
+    if (typeof (cex) === 'function') {
+        cex = ex.cause();
+    }
+    if (cex) {
+        ret += '\nCaused by: ' + getFullErrorStack(cex);
+    }
+    return (ret);
+}
+
 /**
  * Print out a single result, considering input options.
  */
@@ -339,7 +351,7 @@ module.exports = function formatRecord(rec, opts) {
     }
 
     if (rec.err && rec.err.stack) {
-      details.push(indent(rec.err.stack));
+      details.push(indent(getFullErrorStack(rec.err)));
       delete rec.err;
     }
 


### PR DESCRIPTION
(Recursively) if err object has 'cause' property use it as underlying
error and add it to list of "Caused by".
Function getFullErrorStack() is copied (and slightly modified) from bunyan itself.